### PR TITLE
set parallel load of Google API client and bundle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -54,13 +54,11 @@
 
     <script>
         window.OnGoogleAPILoadCallback = function () {
-            var s = document.createElement("script");
-            s.type = "text/javascript";
-            s.src = "./static/bundle.js";
-            document.body.appendChild(s);
+            //Google API client loaded
         }
     </script>
     <script src="https://apis.google.com/js/client.js?onload=OnGoogleAPILoadCallback"></script>
+    <script src="./static/bundle.js"></script>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
### What does this PR do
- remove sequential load of Google API client and app bundle. Was inherited from PlayerManager's repo when YouTube API needed to be requested once API client was loaded. But now, there is enough time to load API client while user interacts with first screen and song search.

This change saves dead time while API client boot-up, reducing the time users see a blank screen.
UI renders once bundle is loaded, so sooner the better.
![loading waterfall chart](https://cloud.githubusercontent.com/assets/1474823/12296970/98a54970-b9e9-11e5-9bac-9e6277676ab9.png)
