### PR TITLE
add warning message before close Player other than close button

### DIFF
--- a/src/components/PlayerManager/index.js
+++ b/src/components/PlayerManager/index.js
@@ -87,6 +87,10 @@ class PlayerManager extends Component {
         };
     }
 
+    componentDidMount() {
+        this._attachCloseWarning();
+    }
+
     componentWillUnmount() {
         for (let TId of this._onScreenTimeoutIds) {
             clearTimeout(TId);
@@ -379,9 +383,29 @@ class PlayerManager extends Component {
         ));
     }
 
+    _attachCloseWarning() {
+        window.onbeforeunload = (event)=> {
+            const message = 'Sure you want to close?';
+            if (typeof event === 'undefined') {
+                event = window.event;
+            }
+
+            if (event) {
+                event.returnValue = message;
+            }
+            return message;
+        };
+    }
+
+    _removeCloseWarning() {
+        window.onbeforeunload = ()=> null;
+    }
+
     close() {
+        this._removeCloseWarning();
         this.props.onClose();
     }
+
 
 }
 


### PR DESCRIPTION
#### What does this PR do?
- attach window.onbeforeunload on Player componentDidMount.
- remove window.onbeforeunload before trigger Player onClose prop.

warning message shows when Player page tries to unload by another way than X button
